### PR TITLE
fix(privacy): unblock CI type check

### DIFF
--- a/holmes-gpt/src/routes/privacy/+page.svelte
+++ b/holmes-gpt/src/routes/privacy/+page.svelte
@@ -10,6 +10,7 @@
     { Icon: Users, label: 'Trusted' }
   ];
   let heroStatIndex = 0;
+  /** @type {ReturnType<typeof setInterval>} */
   let heroStatTimer;
 
   onMount(() => {


### PR DESCRIPTION
## Summary
- heroStatTimer had no type annotation, causing svelte-check to fail under strict mode
- This has been silently blocking build-and-push/deploy since the last two merges (#12, #13) -- confirmed via local `npm run check`: 0 errors now, was 2 errors before

🤖 Generated with [Claude Code](https://claude.com/claude-code)