### PR TITLE
fix: ANTHROPIC_API_KEY secret bridge + contrast/layout fixes

### DIFF
--- a/holmes-gpt/Dockerfile
+++ b/holmes-gpt/Dockerfile
@@ -47,6 +47,11 @@ COPY --from=builder /app/node_modules ./node_modules
 # Copy the quotes data
 COPY --from=builder /app/downloads/training_data ./downloads/training_data
 
+# Bridge the Docker secret at /run/secrets/anthropic_api_key into
+# ANTHROPIC_API_KEY, since the app only reads it from the environment.
+COPY docker-entrypoint.sh ./docker-entrypoint.sh
+RUN chmod +x ./docker-entrypoint.sh
+
 # Create data directory and set permissions for volume mounts
 RUN mkdir -p /app/data && chown -R svelte:nodejs /app
 # Ensure the svelte user can write to the data directory
@@ -61,4 +66,5 @@ VOLUME ["/app/data"]
 EXPOSE 3000
 
 # Start the application using SvelteKit's built-in server
+ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["node", "build"] 

--- a/holmes-gpt/docker-entrypoint.sh
+++ b/holmes-gpt/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ -z "$ANTHROPIC_API_KEY" ] && [ -f /run/secrets/anthropic_api_key ]; then
+  export ANTHROPIC_API_KEY="$(cat /run/secrets/anthropic_api_key)"
+fi
+
+exec "$@"

--- a/holmes-gpt/src/app.css
+++ b/holmes-gpt/src/app.css
@@ -27,6 +27,7 @@
 
     --user-message-bg: linear-gradient(135deg, #667eea, #764ba2);
     --user-message-border: rgba(102, 126, 234, 0.3);
+    --on-user-message-text: white;
     --holmes-message-bg: rgba(247, 250, 252, 0.95);
     --holmes-message-border: rgba(226, 232, 240, 0.6);
 
@@ -57,6 +58,7 @@
 
     --user-message-bg: linear-gradient(135deg, #d4af37, #b8941f);
     --user-message-border: rgba(212, 175, 55, 0.4);
+    --on-user-message-text: #1a1207;
     --holmes-message-bg: rgba(42, 42, 42, 0.95);
     --holmes-message-border: rgba(255, 255, 255, 0.1);
 

--- a/holmes-gpt/src/lib/components/MessageBubble.svelte
+++ b/holmes-gpt/src/lib/components/MessageBubble.svelte
@@ -154,13 +154,13 @@
 		margin-bottom: 0.375rem;
 	}
 
-	/* Ensure proper contrast for user messages */
+	/* Ensure proper contrast for user messages (bubble background is gold) */
 	.user-message {
-		color: white !important;
+		color: #1a1207 !important;
 	}
 
 	.user-message :global(*) {
-		color: white !important;
+		color: #1a1207 !important;
 	}
 
 	/* Holmes message styling */

--- a/holmes-gpt/src/lib/components/MessageBubble.svelte
+++ b/holmes-gpt/src/lib/components/MessageBubble.svelte
@@ -154,13 +154,14 @@
 		margin-bottom: 0.375rem;
 	}
 
-	/* Ensure proper contrast for user messages (bubble background is gold) */
+	/* Ensure proper contrast for user messages -- bubble bg is purple/blue in
+	   light mode, gold in dark mode, so the text color must follow suit */
 	.user-message {
-		color: #1a1207 !important;
+		color: var(--on-user-message-text) !important;
 	}
 
 	.user-message :global(*) {
-		color: #1a1207 !important;
+		color: var(--on-user-message-text) !important;
 	}
 
 	/* Holmes message styling */

--- a/holmes-gpt/src/lib/components/MessageInput.svelte
+++ b/holmes-gpt/src/lib/components/MessageInput.svelte
@@ -229,7 +229,7 @@
 		background: linear-gradient(135deg, var(--text-accent), var(--text-accent-hover));
 		border: none;
 		border-radius: 8px;
-		color: white;
+		color: #1a1207;
 		cursor: pointer;
 		transition: all 0.2s;
 		display: flex;

--- a/holmes-gpt/src/routes/privacy/+page.svelte
+++ b/holmes-gpt/src/routes/privacy/+page.svelte
@@ -265,7 +265,7 @@
             </div>
           </div>
 
-          <div class="contact-card">
+          <div class="contact-card contact-card-address">
             <div class="contact-icon">
               <MapPin size={32} />
             </div>
@@ -1273,10 +1273,18 @@
   .usage-grid,
   .protection-grid,
   .sharing-details,
-  .additional-grid,
-  .contact-grid {
+  .additional-grid {
     grid-template-columns: 1fr;
     gap: 1rem;
+  }
+
+  .contact-grid {
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+  }
+
+  .contact-card-address {
+    grid-column: 1 / -1;
   }
   
   .policy-card,
@@ -1413,10 +1421,6 @@
   }
   
   .additional-grid {
-    grid-template-columns: 1fr;
-  }
-  
-  .contact-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/holmes-gpt/src/routes/privacy/+page.svelte
+++ b/holmes-gpt/src/routes/privacy/+page.svelte
@@ -246,23 +246,25 @@
         
         <div class="contact-grid">
           <div class="contact-card">
-            <div class="contact-icon">
-              <Mail size={32} />
-            </div>
-            <div class="contact-info">
-              <h4>Email</h4>
-              <a href="mailto:ryan@webdevs.net" class="contact-link">ryan@webdevs.net</a>
-            </div>
+            <a href="mailto:ryan@webdevs.net" class="contact-card-link">
+              <div class="contact-icon">
+                <Mail size={32} />
+              </div>
+              <div class="contact-info">
+                <h4>Email</h4>
+              </div>
+            </a>
           </div>
 
           <div class="contact-card">
-            <div class="contact-icon">
-              <Phone size={32} />
-            </div>
-            <div class="contact-info">
-              <h4>Phone</h4>
-              <a href="tel:+13105405080" class="contact-link">(310) 540-5080</a>
-            </div>
+            <a href="tel:+13105405080" class="contact-card-link">
+              <div class="contact-icon">
+                <Phone size={32} />
+              </div>
+              <div class="contact-info">
+                <h4>Phone</h4>
+              </div>
+            </a>
           </div>
 
           <div class="contact-card contact-card-address">
@@ -1159,6 +1161,20 @@
   position: relative;
 }
 
+.contact-card-link {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+}
+
+.contact-card-link:hover .contact-info h4,
+.contact-card-link:hover .contact-icon {
+  color: var(--text-accent-hover);
+}
+
 .contact-card:hover {
   transform: translateY(-2px);
 }
@@ -1296,22 +1312,24 @@
   }
 
   .contact-card {
-    padding: 1rem;
+    padding: 0.75rem 0.5rem;
   }
 
   .contact-icon {
-    padding: 0.75rem;
+    padding: 0.5rem;
     font-size: 0.9rem;
+    margin-bottom: 0.4rem;
   }
 
   .contact-info h4 {
     font-size: 1rem;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.25rem;
   }
 
   .contact-link {
-    padding: 0.4rem 0.8rem;
-    font-size: 0.9rem;
+    padding: 0.4rem 0.4rem;
+    font-size: 0.8rem;
+    white-space: nowrap;
   }
 
   .contact-intro {


### PR DESCRIPTION
## Summary
- **Root fix**: chat has been showing "ANTHROPIC_API_KEY is not configured" in production despite a valid Docker secret being mounted -- nothing ever bridged /run/secrets/anthropic_api_key into the env var the app reads. Added docker-entrypoint.sh to do that.
- User chat bubble text color now theme-aware (bubble bg is purple/blue in light mode, gold in dark mode -- fixing dark mode's contrast without breaking light mode)
- Send button icon: dark text on its gold background (was white, low contrast)
- Privacy page contact cards: Email/Phone are icon+label only now, whole card is the mailto:/tel: link -- fixes the address/phone wrapping to 3 lines, sits side-by-side on mobile

`npm run check`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)